### PR TITLE
优化配置目录

### DIFF
--- a/src/addons/Service.php
+++ b/src/addons/Service.php
@@ -227,7 +227,7 @@ EOD;
             throw new Exception("addons.js文件没有写入权限");
         }
 
-        $file = APP_PATH . 'extra' . DS . 'addons.php';
+        $file = CONF_PATH . 'extra' . DS . 'addons.php';
 
         $config = get_addon_autoload_config(true);
         if ($config['autoload'])


### PR DESCRIPTION
前言:
        众所周知，thinkPHP5.1与thinkPHP6.0系列，配置文件的目录均为config，所以我们这些从5.1到5.0的使用者，习惯将配置文件迁移至config目录。
        在thinkPHP中，CONF_PATH若无手动定义，则与APP_PATH相同，均指向application目录。tp系统操作配置文件的类与方法，均以CONF_PATH为准。入口文件中定义常量CONF_PATH为config之后，与tp相关的配置，均读写config目录。
        在fastadmin中，管理后台向本地写入site.php文件与安装工具向本地写入database.php文件，不会随着CONF_PATH的重新定义而写入confg目录，故Config::get读取不到最新的配置。
        在fastadmin-addons中，安装卸载插件，禁用启用插件，读写的配置文件生成的addons.php同样不会写入config目录。
影响功能：

- 安装程序 将按照CONF_PATH目录写入database.php文件；
- 管理后台 将按照CONF_PATH目录写入site.php文件;
- 插件安装 将按照CONF_PATH目录写入addon.php文件。

影响用户：
        手动指定CONF_PATH目录的开发者，其他用户不受影响。
其他：
        需同步合并fastadmin代码库和fastadmin-addons代码库。