### PR TITLE
fix: 执行composer bin命令时，报Use of undefined constant ROOT_PATH - assumed…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "addons package for fastadmin",
     "homepage": "https://github.com/karsonzhang/fastadmin-addons",
     "license": "Apache-2.0",
-    "version": "1.4.0",
     "authors": [
         {
             "name": "Karson",
@@ -19,6 +18,7 @@
     },
     "require": {
         "php": ">=7.0.0",
+        "topthink/framework": "~5.0",
         "nelexa/zip": "^3.3 || ^4.0"
     },
     "autoload": {
@@ -33,5 +33,10 @@
         "think-config": {
             "addons": "src/config.php"
         }
+    },
+    "scripts": {
+        "pre-autoload-dump": [
+            "composer dump-autoload -o"
+        ]
     }
 }

--- a/src/common.php
+++ b/src/common.php
@@ -13,6 +13,11 @@ use think\Loader;
 use think\Response;
 use think\Route;
 
+if (!defined('ROOT_PATH') && is_file(dirname(__DIR__, 4) . '/vendor/autoload.php')) {
+    define('ROOT_PATH', dirname(__DIR__, 4));
+}
+!defined('DS') && define('DS', DIRECTORY_SEPARATOR);
+
 // 插件目录
 define('ADDON_PATH', ROOT_PATH . 'addons' . DS);
 


### PR DESCRIPTION
… 'ROOT_PATH'

chore: 不建议在composer.json指定版本号。可参阅https://getcomposer.org/doc/04-schema.md#version
chore: 增加pre-autoload-dump后，执行dump-autoload -o